### PR TITLE
French conjugator group1 present

### DIFF
--- a/src/french.js
+++ b/src/french.js
@@ -37,13 +37,13 @@ class French {
     if (info.singular === true) {
       if (info.person === '2' && info.formal === true){
         //if the subject ('you') is meant as formal and singular, it is conjugated as plural, but the past participle stays singular
-        return 'p' + info.person;
+        return 'p2';
       }
       return 's' + info.person;
     } else {
       if (info.person === '3' && info.gender === 'unknown'){
         //if the subject is plural and undefined ('on'), is is conjugated as singular, but the past participle stays plural
-        return 's' + info.person;
+        return 's3';
       }
       return 'p' + info.person;
     }
@@ -73,10 +73,9 @@ class French {
     // in some cases there are several stem solutions
     // those cases apply to all tenses
     let combinations = [];
-
-    if (group === group1) {
+    if (group === 'group1') {
       // rules for group1: verbs ending in -er
-      if (ending.charAt(0) === 'a' || ending.charAt(0) === 'O') {
+      if (ending.charAt(0) === 'a' || ending.charAt(0) === 'o') {
         // cases of tense endings: 'a' or 'o'
         if (stem.charAt(stem.length - 1) === 'c') {
           // verbs ending in -cer
@@ -94,21 +93,21 @@ class French {
           if (stem.slice(-2) === 'el' || stem.slice(-2) === 'et') {
             // verbs ending in -eler or -eter
             // special cases of -el and -et that always become -èl and -èt
-            const elExceptions = ['cel', 'décel', 'recel', 'cisel', 'démantel', 'écartel', 'encastel', 'gel', 'dégel', 'congel', 'surgel', 'martel', 'model', 'pel'];
+            const elExceptions = ['cel', 'décel', 'recel', 'cisel', 'démantel', 'écartel', 'encastel', 'gel', 'dégel', 'congel', 'surgel', 'décongel', 'martel', 'model', 'pel', 'remodel'];
             const etExceptions = ['achet', 'rachet', 'béguet', 'corset', 'crochet', 'filet', 'furet', 'halet'];
             // special cases of -el and -et that always become -ell and -ett
             const patternCase1 = /jet$/;
             const patternCase2 = /appel$/;
             const case3 = 'interpel';
 
-            if(elExceptions.indexOf('stem') !== -1 || etExceptions.indexOf('stem') !== -1) {
+            if(elExceptions.indexOf(stem) !== -1 || etExceptions.indexOf(stem) !== -1) {
               return [stem.slice(0, -2) + 'è' + stem.slice(-1) + ending];
             } else if (patternCase1.test(stem) || patternCase2.test(stem) || stem === case3) {
               return [stem + stem.slice(-1) + ending];
             } else {
               //all other cases can have two solutions: (-èl and -èt) or (-ell and -ett)
-              combinations[0] = stem.slice(0, -2) + 'è' + stem.slice(-1) + ending;
-              combinations[1] = stem + stem.slice(-1) + ending;
+              combinations[0] = stem + stem.slice(-1) + ending;
+              combinations[1] = stem.slice(0, -2) + 'è' + stem.slice(-1) + ending;
               return combinations;
             }
           } else if (stem.slice(-3) === 'evr') {
@@ -151,29 +150,6 @@ class French {
   }
 
   doPresent (word, info) {
-    const subject = this.findSubject (info);
-
-    if (word === être || word === avoir || word === aller) {
-      return word[subject];
-    }
-
-    const verbProperties = this.findWordGroup (word);
-    const group = verbProperties[0];
-    const stem = verbProperties[1];
-
-    if (group === 'group1') {
-      //temperory test until other groups implemented
-      const solutions = combineToConjugate(group, stem, tenseEnding[group][subject]);
-      if (solutions.length > 1) {
-        return solutions[0] + ' / ' + solutions[1];
-      } else {
-        return solutions[0];
-      }
-    } else {
-      return 'not yet implemented'
-    }
-
-
     const tenseEnding = {
       group1: {
         s1: 'e',
@@ -192,32 +168,54 @@ class French {
         p3: 'ent'
       }
     };
+    const specialVerbs = {
+      être: {
+        s1: 'suis',
+        s2: 'es',
+        s3: 'est',
+        p1: 'sommes',
+        p2: 'êtes',
+        p3: 'sont'
+      },
+      avoir: {
+        s1: 'ai',
+        s2: 'as',
+        s3: 'a',
+        p1: 'avons',
+        p2: 'avez',
+        p3: 'ont'
+      },
+      aller: {
+        s1: 'vais',
+        s2: 'vas',
+        s3: 'va',
+        p1: 'allons',
+        p2: 'allez',
+        p3: 'vont'
+      }
+    };
 
-    const être = {
-      s1: 'suis',
-      s2: 'es',
-      s3: 'est',
-      p1: 'sommes',
-      p2: 'êtes',
-      p3: 'sont'
+    const subject = this.findSubject (info);
+
+    if (word === 'être' || word === 'avoir' || word === 'aller') {
+      return specialVerbs[word][subject];
     }
 
-    const avoir = {
-      s1: 'ai',
-      s2: 'as',
-      s3: 'a',
-      p1: 'avons',
-      p2: 'avez',
-      p3: 'ont'
-    }
+    const verbProperties = this.findWordGroup (word);
+    const group = verbProperties[0];
+    const stem = verbProperties[1];
 
-    const aller = {
-      s1: 'vais',
-      s2: 'vas',
-      s3: 'va',
-      p1: 'allons',
-      p2: 'allez',
-      p3: 'vont'
+    if (group === 'group1') {
+      //temperory test until other groups implemented
+      const solutions = this.combineToConjugate(group, stem, tenseEnding[group][subject]);
+      if (solutions.length > 1) {
+        return solutions[0] + ' / ' + solutions[1];
+      } else {
+        return solutions[0];
+      }
+    } else {
+      return 'not yet implemented'
     }
   }
 }
+export { French };

--- a/src/french.js
+++ b/src/french.js
@@ -1,9 +1,28 @@
 class French {
-
+  /*
+      word: verb in infinitif form -> can be divided in a stem and an ending
+        TODO: pronominal verbs: 'se' + infinitif
+        TODO: passive form: 'être' + past participle
+      info: {
+        tense: 'present'/'past'/'future'/'simple past'/..., (!!!tenses different from english tenses)
+        person (subject): '1'/'2'/'3',
+          '1': Je, nous (I, we),
+          '2': tu, vous (you),
+          '3': he, she, they, it, undefined ('on', people, infinitif verb, object, 'ça', 'cela', ...)
+        singular: 'true/false',
+          if undefined subject: 'on' (english: we as a whole, it), people, infinitif verb, qui, tout, rien, object -> is considered singular -> true
+          ! 'on' can also be used instead of 'nous' (but this use is to be avoided) -> is considered plural -> false
+          true -> singular -> 's'
+          false -> plural -> 'p'
+        formal: 'true/false',
+          'vous' can be used to adress a singular person in a formal way -> if the subject is 's2' and formal, it is conjugated as 'p2', but the past participle stays singular
+        gender: 'female/male/unknown',
+          undefined subject: ils (english: they), nous (english: we) , vous (you, adressing a group of persons), the people -> is conjugated as male, when we don't know who 'they', 'nous', 'vous' represent (male or female)
+          unknown: only for 'on' with the meaning 'it'
+          ! 'on' and objects 'can' also have a gender !
+      }
+  */
   conjugate (word, info) {
-    // Format for info: {tense: 'present', formal: 'true/false', gender: 'female/male/undefined', singular: 'true/false/undefined', person: '1'/'2'/'3'}
-    //TODO define 3 verb group types
-
    switch (info.tense) {
      case 'present':
        return this.doPresent(word, info);
@@ -13,56 +32,192 @@ class French {
    }
   }
 
-  defineVerbType (word) {
-    const group3 = ['avoir', 'être'];
-
-    if (group3.indexOf(word) > -1 || word.slice(-2) === 're') {
-      if (word === 'être') {
-        return 'être';
-      } else if (word === 'avoir') {
-        return 'avoir';
-      } else {
-        //TODO
+  findSubject (info) {
+    // returns the subject for conjugation: 's1'/'s2'/'s3'/'p1'/'p2'/'p3'
+    if (info.singular === true) {
+      if (info.person === '2' && info.formal === true){
+        //if the subject ('you') is meant as formal and singular, it is conjugated as plural, but the past participle stays singular
+        return 'p' + info.person;
       }
-    } else if (word.slice(-2) === 'er') {
-      //TODO
-    } else if (word.slice(-2) === 'ir') {
-      //TODO
+      return 's' + info.person;
+    } else {
+      if (info.person === '3' && info.gender === 'unknown'){
+        //if the subject is plural and undefined ('on'), is is conjugated as singular, but the past participle stays plural
+        return 's' + info.person;
+      }
+      return 'p' + info.person;
     }
+  }
+
+  findWordGroup (word) {
+    // returns group1/group2/group3 depending on ending of the infinif form of the verb
+    // group1: all verbs ending in -er except the verb 'aller'
+    // group2: all verbs ending in -ir except the irregular verbs ending in -ir
+    // group3: irregular verbs ending in -ir, -re, -oir, TODO define subgroups
+    let stem = word.slice(0, -2);
+    let ending = word.slice(-2);
+    if (ending === 'er') {
+      return ['group1', stem];
+    } else if ((ending === 'ir' || ending === 'ïr') && stem.slice(-1) !== 'o') {
+      if (/tenir$/.test(word) || /venir$/.test(word)) {
+        return ['group3', stem];
+      } else if (/quérir$/.test(word)) {
+        return ['group3', stem];
+      }
+      //TODO finish defining group3 and group2
+    }
+  }
+
+  combineToConjugate (group, stem, ending) {
+    // the last letter of the stem and the first letter of the tense ending affect each other in some specific cases
+    // in some cases there are several stem solutions
+    // those cases apply to all tenses
+    let combinations = [];
+
+    if (group === group1) {
+      // rules for group1: verbs ending in -er
+      if (ending.charAt(0) === 'a' || ending.charAt(0) === 'O') {
+        // cases of tense endings: 'a' or 'o'
+        if (stem.charAt(stem.length - 1) === 'c') {
+          // verbs ending in -cer
+          return [stem.slice(0, -1) + 'ç' + ending];
+        } else if (stem.charAt(stem.length - 1) === 'g') {
+          // verbs ending in -ger
+          return [stem + 'e' + ending];
+        }
+      }
+      if (ending.charAt(0) === 'e' && ending.charAt(1) !== 'z') {
+        // cases of tense endings: '-e', '-es', '-ent' and '-er(.)'
+        const globalPattern = /e[cmnprsvlt]/;
+        if (globalPattern.test(stem.slice(-2)) || stem.slice(-3) === 'evr') {
+          // verbs ending in -e(.)er and (.) can only be either 'c', 'm', 'n', 'p', 'r', 's', 'v', 'vr', 'l', 't'
+          if (stem.slice(-2) === 'el' || stem.slice(-2) === 'et') {
+            // verbs ending in -eler or -eter
+            // special cases of -el and -et that always become -èl and -èt
+            const elExceptions = ['cel', 'décel', 'recel', 'cisel', 'démantel', 'écartel', 'encastel', 'gel', 'dégel', 'congel', 'surgel', 'martel', 'model', 'pel'];
+            const etExceptions = ['achet', 'rachet', 'béguet', 'corset', 'crochet', 'filet', 'furet', 'halet'];
+            // special cases of -el and -et that always become -ell and -ett
+            const patternCase1 = /jet$/;
+            const patternCase2 = /appel$/;
+            const case3 = 'interpel';
+
+            if(elExceptions.indexOf('stem') !== -1 || etExceptions.indexOf('stem') !== -1) {
+              return [stem.slice(0, -2) + 'è' + stem.slice(-1) + ending];
+            } else if (patternCase1.test(stem) || patternCase2.test(stem) || stem === case3) {
+              return [stem + stem.slice(-1) + ending];
+            } else {
+              //all other cases can have two solutions: (-èl and -èt) or (-ell and -ett)
+              combinations[0] = stem.slice(0, -2) + 'è' + stem.slice(-1) + ending;
+              combinations[1] = stem + stem.slice(-1) + ending;
+              return combinations;
+            }
+          } else if (stem.slice(-3) === 'evr') {
+            // verbs ending in -evrer
+            return [stem.slice(0, -3) + 'èvr' + ending];
+          } else {
+            // verbs ending in -e(.)er where (.) is either 'c', 'm', 'n', 'p', 'r', 's', 'v'
+            return [stem.slice(0, -2) + 'è' + stem.slice(-1) + ending];
+          }
+        }
+
+        if (/[aou]y/.test(stem.slice(-2))) {
+          //verbs ending in -ayer, -oyer or -uyer
+          if (/envoy/.test(stem) && ending.charAt(1) === 'r') {
+            // exceptions: verbs with '-envoy-' in the stem, like envoyer, renvoyer,...
+            return [stem.slice(0, -2) + 'er' + ending.slice(2)];
+          } else {
+            combinations[0] = stem.slice(0,-1) + 'i' + ending;
+            if (stem.charAt(stem.length - 2) === 'a') {
+              combinations[1] = stem + ending;
+            }
+            return combinations;
+          }
+        }
+
+        if (ending.charAt(1) !== 'r') {
+          // cases of endings: '-e', '-es' and '-ent'
+          // verbs ending in -é(.)er
+          if (stem.substr(-2, 1) === 'é') {
+            return [stem.slice(0, -2) + 'è' + stem.slice(-1) + ending];
+          } else if (stem.substr(-3, 1) === 'é'){
+            return [stem.slice(0, -3) + 'è' + stem.slice(-2) + ending];
+          }
+        }
+      }
+      return [stem + ending];
+      //end group1
+    }
+    //TODO define the rules for group2 and group3
   }
 
   doPresent (word, info) {
-    const verbType = this.defineVerbType(word);
-    switch (verbType) {
-      case 'être':
-        switch (info.person) {
-          case '1':
-            if (info.singular === true) {
-              return 'suis';
-            } else {
-              return 'sommes';
-            }
-            break;
-          case '2':
-            if (info.singular === true && info.formal === false) {
-              return 'es';
-            } else {
-              return 'êtes';
-            }
-            break;
-          case '3':
-            if (info.singular === true || info.singular === 'undefined') {
-              return 'est';
-            } else {
-              return 'sont';
-            }
-            break;
-          }
-          break;
-        default:
-          return 'Verb not in our database';
+    const subject = this.findSubject (info);
+
+    if (word === être || word === avoir || word === aller) {
+      return word[subject];
+    }
+
+    const verbProperties = this.findWordGroup (word);
+    const group = verbProperties[0];
+    const stem = verbProperties[1];
+
+    if (group === 'group1') {
+      //temperory test until other groups implemented
+      const solutions = combineToConjugate(group, stem, tenseEnding[group][subject]);
+      if (solutions.length > 1) {
+        return solutions[0] + ' / ' + solutions[1];
+      } else {
+        return solutions[0];
+      }
+    } else {
+      return 'not yet implemented'
+    }
+
+
+    const tenseEnding = {
+      group1: {
+        s1: 'e',
+        s2: 'es',
+        s3: 'e',
+        p1: 'ons',
+        p2: 'ez',
+        p3: 'ent'
+      },
+      group2: {
+        s1: 's',
+        s2: 's',
+        s3: 't',
+        p1: 'ons',
+        p2: 'ez',
+        p3: 'ent'
+      }
+    };
+
+    const être = {
+      s1: 'suis',
+      s2: 'es',
+      s3: 'est',
+      p1: 'sommes',
+      p2: 'êtes',
+      p3: 'sont'
+    }
+
+    const avoir = {
+      s1: 'ai',
+      s2: 'as',
+      s3: 'a',
+      p1: 'avons',
+      p2: 'avez',
+      p3: 'ont'
+    }
+
+    const aller = {
+      s1: 'vais',
+      s2: 'vas',
+      s3: 'va',
+      p1: 'allons',
+      p2: 'allez',
+      p3: 'vont'
     }
   }
 }
-
-export { French };

--- a/src/french.js
+++ b/src/french.js
@@ -4,6 +4,7 @@ class French {
         TODO: pronominal verbs: 'se' + infinitif
         TODO: passive form: 'être' + past participle
       info: {
+        mood: 'Indicatif'/'Subjonctif'/'Impératif'/'Conditionnel'/'Infinitif'/'Participe'
         tense: 'present'/'past'/'future'/'simple past'/..., (!!!tenses different from english tenses)
         person (subject): '1'/'2'/'3',
           '1': Je, nous (I, we),
@@ -23,13 +24,90 @@ class French {
       }
   */
   conjugate (word, info) {
-   switch (info.tense) {
-     case 'present':
-       return this.doPresent(word, info);
-       break;
-     default:
-       return 'Could not find any rules for conjugation';
-   }
+    switch (info.mood) {
+      case 'Indicatif':
+        switch (info.tense) {
+          case 'Présent':
+            return this.doIndicatifPresent(word, info);
+            break;
+          case 'Passé Composé':
+            break;
+          case 'Imparfait':
+            break;
+          case 'Plus-que-parfait':
+            break;
+          case 'Passé Simple':
+            break;
+          case 'Passé Antérieur':
+            break;
+          case 'Futur Simple':
+            break;
+          case 'Futur Antérieur':
+            break;
+          default:
+            return 'Indicatif Tense not found';
+        }
+        break;
+      case 'Infinitif':
+        switch (info.tense) {
+          case 'Présent':
+           return word;
+           break;
+          case 'Passé':
+            break;
+          default:
+            return 'Infinitif Tense not found';
+        }
+        break;
+      case 'Participe':
+        switch (info.tense) {
+          case 'Présent':
+           break;
+          case 'Passé':
+            break;
+          default:
+            return 'Participe Tense not found';
+        }
+        break;
+      case 'Subjonctif':
+        switch (info.tense) {
+          case 'Présent':
+            break;
+          case 'Passé':
+            break;
+          case 'Imparfait':
+            break;
+          case 'Plus-que-parfait':
+            break;
+          default:
+            return 'Subjonctif Tense not found';
+        }
+        break;
+      case 'Impératif':
+        switch (info.tense) {
+          case 'Présent':
+            break;
+          case 'Passé':
+            break;
+          default:
+            return 'Impératif Tense not found';
+        }
+        break;
+      case 'Conditionnel':
+        switch (info.tense) {
+          case 'Présent':
+            break;
+          case 'Passé 1':
+            break;
+          case 'Passé 2':
+            break;
+          default:
+          return 'Conditionnel Tense not found';
+        }
+        break;
+      default:
+        return 'Mood not found';
+    }
   }
 
   findSubject (info) {
@@ -53,18 +131,142 @@ class French {
     // returns group1/group2/group3 depending on ending of the infinif form of the verb
     // group1: all verbs ending in -er except the verb 'aller'
     // group2: all verbs ending in -ir except the irregular verbs ending in -ir
-    // group3: irregular verbs ending in -ir, -re, -oir, TODO define subgroups
+    // group3: irregular verbs ending in -ir, -re, -oir
     let stem = word.slice(0, -2);
     let ending = word.slice(-2);
+
     if (ending === 'er') {
       return ['group1', stem];
     } else if ((ending === 'ir' || ending === 'ïr') && stem.slice(-1) !== 'o') {
-      if (/tenir$/.test(word) || /venir$/.test(word)) {
-        return ['group3', stem];
+      // all groups of irregular verbs ending in -ir
+      if (/[tv]enir$/.test(word)) {
+        return ['group3-1', stem];
       } else if (/quérir$/.test(word)) {
-        return ['group3', stem];
+        return ['group3-2', stem];
+      } else if (/(?:[ms]|rep)entir$/.test(word) || /(?:so|pa)rtir$/.test(word)) {
+        return ['group3-3', stem];
+      } else if (/vêtir$/.test(word)) {
+        return ['group3-4', stem];
+      } else if (/ouvrir$/.test(word) || /(?:o|sou)ffrir$/.test(word)){
+        return ['group3-5', stem];
+      } else if (/cueillir$/.test(word)) {
+        return ['group3-6', stem];
+      } else if (/(?:s|f)aillir$/.test(word)) {
+        return ['group3-7', stem];
+      } else if (/bouillir$/.test(word)) {
+        return ['group3-8', stem];
+      } else if (/dormir$/.test(word)) {
+        return ['group3-9', stem];
+      } else if (/courir$/.test(word)) {
+        return ['group3-10', stem];
+      } else if (/mourir$/.test(word)) {
+        return ['group3-11', stem];
+      } else if (/(?:s|dess|ress)ervir$/.test(word)) {
+        return ['group3-12', stem];
+      } else if (/fuir$/.test(word)) {
+        return ['group3-13', stem];
+      } else if (word === 'ouïr') {
+        return ['group3-14', stem];
+      } else if (word === 'gésir') {
+        return ['group3-15', stem];
+      } else {
+        stem += ending.charAt(0);
+        return ['group2', stem]
       }
-      //TODO finish defining group3 and group2
+    } else if (ending === 'ir' && stem.slice(-1) === 'o') {
+      if (/cevoir$/.test(word)) {
+        return ['group3-16', stem];
+      } else if (/pourvoir$/.test(word)) {
+        return ['group3-17', stem];
+      } else if (/savoir$/.test(word)) {
+        return ['group3-18', stem];
+      } else if (/devoir$/.test(word)) {
+        return ['group3-19', stem];
+      } else if (/pouvoir$/.test(word)) {
+        return ['group3-20', stem];
+      } else if (/mouvoir$/.test(word)) {
+        return ['group3-21', stem];
+      } else if (/pleuvoir$/.test(word)) {
+        return ['group3-22', stem];
+      } else if (/voir$/.test(word)) {
+        return ['group3-23', stem];
+      } else if (/falloir$/.test(word)) {
+        return ['group3-24', stem];
+      } else if (/valoir$/.test(word)) {
+        return ['group3-25', stem];
+      } else if (/vouloir$/.test(word)) {
+        return ['group3-26', stem];
+      } else if (word === 'seoir') {
+        return ['group3-27', stem];
+      } else if (/asseoir$/.test(word)) {
+        return ['group3-28', stem];
+      } else if (/messeoir$/.test(word)) {
+        return ['group3-29', stem];
+      } else if (/surseoir$/.test(word)) {
+        return ['group3-30', stem];
+      } else if (/choir$/.test(word)) {
+        return ['group3-31', stem];
+      }
+    } else if (ending === 're') {
+      if (/[nr][dc]re$/.test(word)) {
+        if (/prendre$/.test(word)) {
+          return ['group3-32', stem];
+        } else if (/eindre$/.test(word)) {
+          return ['group3-33', stem];
+        } else if (/oindre$/.test(word)) {
+          return ['group3-34', stem];
+        } else if (/aindre$/.test(word)) {
+          return ['group3-35', stem];
+        } else if (/aincre$/.test(word)) {
+          return ['group3-36', stem];
+        } else if (/dre$/.test(word)) {
+          return ['group3-37', stem];
+        }
+      } else if (/battre$/.test(word)) {
+        return ['group3-38', stem];
+      } else if (/mettre$/.test(word)) {
+        return ['group3-39', stem];
+      } else if (/(?:t|b)raire$/.test(word)) {
+        return ['group3-40', stem];
+      } else if (/faire$/.test(word)) {
+        return ['group3-41', stem];
+      } else if (/(?:pl|t)aire$/.test(word)) {
+        return ['group3-42', stem];
+      } else if (/aître$/.test(word)) {
+        return ['group3-43', stem];
+      } else if (/oître$/.test(word)) {
+        return ['group3-44', stem];
+      } else if (/croire$/.test(word)) {
+        return ['group3-45', stem];
+      } else if (/boire$/.test(word)) {
+        return ['group3-46', stem];
+      } else if (/clore$/.test(word)) {
+        return ['group3-47', stem];
+      } else if (/clure$/.test(word)) {
+        return ['group3-48', stem];
+      } else if (/soudre$/.test(word)) {
+        return ['group3-49', stem];
+      } else if (/coudre$/.test(word)) {
+        return ['group3-50', stem];
+      } else if (/moudre$/.test(word)) {
+        return ['group3-51', stem];
+      } else if (/suivre$/.test(word)) {
+        return ['group3-52', stem];
+      } else if (/vivre$/.test(word)) {
+        return ['group3-53', stem];
+      } else if (/lire$/.test(word)) {
+        return ['group3-54', stem];
+      } else if (/dire$/.test(word)) {
+        return ['group3-55', stem];
+      } else if (/crire$/.test(word)) {
+        return ['group3-56', stem];
+      } else if (/rire$/.test(word)) {
+        return ['group3-57', stem];
+      } else if (/(?:suf|con)fire$/.test(word) || /circoncire$/.test(word) || /frire$/.test(word)) {
+        return ['group3-58', stem];
+      } else if (/uire$/.test(word)) {
+        return ['group3-59', stem];
+      }
     }
   }
 
@@ -145,29 +347,13 @@ class French {
       }
       return [stem + ending];
       //end group1
+    } else if (group === 'group2') {
+    } else if (/^group3/.test(group)) {
+      //TODO define the rules for and group3
     }
-    //TODO define the rules for group2 and group3
   }
 
-  doPresent (word, info) {
-    const tenseEnding = {
-      group1: {
-        s1: 'e',
-        s2: 'es',
-        s3: 'e',
-        p1: 'ons',
-        p2: 'ez',
-        p3: 'ent'
-      },
-      group2: {
-        s1: 's',
-        s2: 's',
-        s3: 't',
-        p1: 'ons',
-        p2: 'ez',
-        p3: 'ent'
-      }
-    };
+  doIndicatifPresent (word, info) {
     const specialVerbs = {
       être: {
         s1: 'suis',
@@ -194,6 +380,24 @@ class French {
         p3: 'vont'
       }
     };
+    const tenseEnding = {
+      ending1: {
+        s1: 'e',
+        s2: 'es',
+        s3: 'e',
+        p1: 'ons',
+        p2: 'ez',
+        p3: 'ent'
+      },
+      ending2: {
+        s1: 's',
+        s2: 's',
+        s3: 't',
+        p1: 'ons',
+        p2: 'ez',
+        p3: 'ent'
+      }
+    };
 
     const subject = this.findSubject (info);
 
@@ -203,18 +407,15 @@ class French {
 
     const verbProperties = this.findWordGroup (word);
     const group = verbProperties[0];
-    const stem = verbProperties[1];
+    let stem = verbProperties[1];
 
     if (group === 'group1') {
-      //temperory test until other groups implemented
-      const solutions = this.combineToConjugate(group, stem, tenseEnding[group][subject]);
+      let solutions = this.combineToConjugate(group, stem, tenseEnding['ending1'][subject]);
       if (solutions.length > 1) {
         return solutions[0] + ' / ' + solutions[1];
       } else {
         return solutions[0];
       }
-    } else {
-      return 'not yet implemented'
     }
   }
 }

--- a/src/french.js
+++ b/src/french.js
@@ -348,6 +348,10 @@ class French {
       return [stem + ending];
       //end group1
     } else if (group === 'group2') {
+      if (/^[aeio]/.test(ending) && ending.length > 1) {
+        stem += 'ss';
+      }
+      return [stem + ending];
     } else if (/^group3/.test(group)) {
       //TODO define the rules for and group3
     }
@@ -416,6 +420,14 @@ class French {
       } else {
         return solutions[0];
       }
+    } else if (group === 'group2') {
+      if (/ï$/.test(stem) && /^s/.test(subject)) {
+        stem = stem.slice(0,-1) + 'i';
+      }
+      let solutions = this.combineToConjugate(group, stem, tenseEnding['ending2'][subject]);
+      return solutions[0];
+    } else {
+      return 'not yet implemented'
     }
   }
 }

--- a/test/french_tests.js
+++ b/test/french_tests.js
@@ -5,70 +5,82 @@ import { French } from '../src/french';
 
 
 describe('French', () => {
-  describe('Present Tense', () => {
+  describe('Indicatif Présent', () => {
     it('should conjugate "être", "avoir", "aller" and verbs ending in "-er" correctly', () => {
       let conjugatedWord;
       const fr = new French();
 
-      conjugatedWord = fr.conjugate('avoir', {tense: 'present', formal: false, singular: false, person: '3', gender: 'unknown'});
+      conjugatedWord = fr.conjugate('aimer', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '3', gender: 'unknown'});
+      expect(conjugatedWord).to.equal('aime');
+
+      conjugatedWord = fr.conjugate('avoir', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '3', gender: 'unknown'});
       expect(conjugatedWord).to.equal('a');
 
-      conjugatedWord = fr.conjugate('aller', {tense: 'present', formal: false, singular: true, person: '2', gender: 'female'});
+      conjugatedWord = fr.conjugate('aller', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '2', gender: 'female'});
       expect(conjugatedWord).to.equal('vas');
 
-      conjugatedWord = fr.conjugate('manger', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('manger', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('mangeons');
 
-      conjugatedWord = fr.conjugate('placer', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('placer', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('plaçons');
 
-      conjugatedWord = fr.conjugate('peser', {tense: 'present', formal: false, singular: false, person: '3', gender: 'male'});
+      conjugatedWord = fr.conjugate('peser', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '3', gender: 'male'});
       expect(conjugatedWord).to.equal('pèsent');
 
-      conjugatedWord = fr.conjugate('peser', {tense: 'present', formal: true, singular: false, person: '2', gender: 'male'});
+      conjugatedWord = fr.conjugate('peser', {mood: 'Indicatif', tense: 'Présent', formal: true, singular: false, person: '2', gender: 'male'});
       expect(conjugatedWord).to.equal('pesez');
 
-      conjugatedWord = fr.conjugate('céder', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('céder', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('cède');
 
-      conjugatedWord = fr.conjugate('céder', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('céder', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('cédons');
 
-      conjugatedWord = fr.conjugate('rejeter', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('rejeter', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('rejette');
 
-      conjugatedWord = fr.conjugate('rejeter', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('rejeter', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('rejetons');
 
-      conjugatedWord = fr.conjugate('modeler', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('modeler', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('modèle');
 
-      conjugatedWord = fr.conjugate('modeler', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('modeler', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('modelons');
 
-      conjugatedWord = fr.conjugate('niveler', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('niveler', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('nivelle / nivèle');
 
-      conjugatedWord = fr.conjugate('niveler', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('niveler', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('nivelons');
 
-      conjugatedWord = fr.conjugate('assiéger', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('assiéger', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('assiège');
 
-      conjugatedWord = fr.conjugate('assiéger', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('assiéger', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('assiégeons');
 
-      conjugatedWord = fr.conjugate('payer', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('payer', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('paie / paye');
 
-      conjugatedWord = fr.conjugate('payer', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('payer', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('payons');
 
-      conjugatedWord = fr.conjugate('broyer', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('broyer', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('broie');
 
-      conjugatedWord = fr.conjugate('broyer', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      conjugatedWord = fr.conjugate('broyer', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('broyons');
+    });
+  });
+
+  describe('Infinitif Présent', () => {
+    it('should conjugate the Infinitif Présent correctly', () => {
+      let conjugatedWord;
+      const fr = new French();
+      conjugatedWord = fr.conjugate('broyer', {mood: 'Infinitif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('broyer');
     });
   });
 });

--- a/test/french_tests.js
+++ b/test/french_tests.js
@@ -10,29 +10,66 @@ describe('French', () => {
       let conjugatedWord;
       const fr = new French();
 
-      conjugatedWord = fr.conjugate('être', {tense: 'present', formal: false, singular: true, person: '1'});
-      expect(conjugatedWord).to.equal('suis');
+      conjugatedWord = fr.conjugate('avoir', {tense: 'present', formal: false, singular: false, person: '3', gender: 'unknown'});
+      expect(conjugatedWord).to.equal('a');
 
-      conjugatedWord = fr.conjugate('être', {tense: 'present', formal: false, singular: true, person: '2'});
-      expect(conjugatedWord).to.equal('es');
+      conjugatedWord = fr.conjugate('aller', {tense: 'present', formal: false, singular: true, person: '2', gender: 'female'});
+      expect(conjugatedWord).to.equal('vas');
 
-      conjugatedWord = fr.conjugate('être', {tense: 'present', formal: false, singular: 'undefined', person: '3'});
-      expect(conjugatedWord).to.equal('est');
+      conjugatedWord = fr.conjugate('manger', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('mangeons');
 
-      conjugatedWord = fr.conjugate('être', {tense: 'present', formal: false, singular: true, person: '3' });
-      expect(conjugatedWord).to.equal('est');
+      conjugatedWord = fr.conjugate('placer', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('plaçons');
 
-      conjugatedWord = fr.conjugate('être', {tense: 'present', formal: false, singular: false, person: '1' });
-      expect(conjugatedWord).to.equal('sommes');
+      conjugatedWord = fr.conjugate('peser', {tense: 'present', formal: false, singular: false, person: '3', gender: 'male'});
+      expect(conjugatedWord).to.equal('pèsent');
 
-      conjugatedWord = fr.conjugate('être', {tense: 'present', formal: false, singular: false, person: '2' });
-      expect(conjugatedWord).to.equal('êtes');
+      conjugatedWord = fr.conjugate('peser', {tense: 'present', formal: true, singular: false, person: '2', gender: 'male'});
+      expect(conjugatedWord).to.equal('pesez');
 
-      conjugatedWord = fr.conjugate('être', {tense: 'present', formal: true, singular: true, person: '2' });
-      expect(conjugatedWord).to.equal('êtes');
+      conjugatedWord = fr.conjugate('céder', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('cède');
 
-      conjugatedWord = fr.conjugate('être', {tense: 'present', formal: false, singular: false, person: '3' });
-      expect(conjugatedWord).to.equal('sont');
+      conjugatedWord = fr.conjugate('céder', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('cédons');
+
+      conjugatedWord = fr.conjugate('jeter', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('jette');
+
+      conjugatedWord = fr.conjugate('jeter', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('jetons');
+
+      conjugatedWord = fr.conjugate('modeler', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('modèle');
+
+      conjugatedWord = fr.conjugate('modeler', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('modelons');
+
+      conjugatedWord = fr.conjugate('niveler', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('nivèle / nivelle');
+
+      conjugatedWord = fr.conjugate('niveler', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('nivelons');
+
+      conjugatedWord = fr.conjugate('assiéger', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('assiège');
+
+      conjugatedWord = fr.conjugate('assiéger', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('assiégeons');
+
+      conjugatedWord = fr.conjugate('payer', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('paie / paye');
+
+      conjugatedWord = fr.conjugate('payer', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('payons');
+
+      conjugatedWord = fr.conjugate('broyer', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('paie');
+
+      conjugatedWord = fr.conjugate('broyer', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('broyons');
+
     });
 
     it('should tell verb not in our database yet', () => {

--- a/test/french_tests.js
+++ b/test/french_tests.js
@@ -6,7 +6,7 @@ import { French } from '../src/french';
 
 describe('French', () => {
   describe('Present Tense', () => {
-    it('should conjugate être present tense correctly', () => {
+    it('should conjugate "être", "avoir", "aller" and verbs ending in "-er" correctly', () => {
       let conjugatedWord;
       const fr = new French();
 
@@ -34,11 +34,11 @@ describe('French', () => {
       conjugatedWord = fr.conjugate('céder', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('cédons');
 
-      conjugatedWord = fr.conjugate('jeter', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
-      expect(conjugatedWord).to.equal('jette');
+      conjugatedWord = fr.conjugate('rejeter', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('rejette');
 
-      conjugatedWord = fr.conjugate('jeter', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
-      expect(conjugatedWord).to.equal('jetons');
+      conjugatedWord = fr.conjugate('rejeter', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('rejetons');
 
       conjugatedWord = fr.conjugate('modeler', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('modèle');
@@ -47,7 +47,7 @@ describe('French', () => {
       expect(conjugatedWord).to.equal('modelons');
 
       conjugatedWord = fr.conjugate('niveler', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
-      expect(conjugatedWord).to.equal('nivèle / nivelle');
+      expect(conjugatedWord).to.equal('nivelle / nivèle');
 
       conjugatedWord = fr.conjugate('niveler', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('nivelons');
@@ -65,22 +65,10 @@ describe('French', () => {
       expect(conjugatedWord).to.equal('payons');
 
       conjugatedWord = fr.conjugate('broyer', {tense: 'present', formal: false, singular: true, person: '1', gender: 'male'});
-      expect(conjugatedWord).to.equal('paie');
+      expect(conjugatedWord).to.equal('broie');
 
       conjugatedWord = fr.conjugate('broyer', {tense: 'present', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('broyons');
-
-    });
-
-    it('should tell verb not in our database yet', () => {
-      let conjugatedWord;
-      const fr = new French();
-
-      conjugatedWord = fr.conjugate('avoir', {tense: 'present', formal: false, singular: true, person: '1'});
-      expect(conjugatedWord).to.equal('Verb not in our database');
-
-      conjugatedWord = fr.conjugate('danser', {tense: 'present', formal: false, singular: true, person: '1'});
-      expect(conjugatedWord).to.equal('Verb not in our database');
     });
   });
 });

--- a/test/french_tests.js
+++ b/test/french_tests.js
@@ -73,6 +73,20 @@ describe('French', () => {
       conjugatedWord = fr.conjugate('broyer', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
       expect(conjugatedWord).to.equal('broyons');
     });
+
+    it('should conjugate regular verbs ending in "-ir" correctly', () => {
+      let conjugatedWord;
+      const fr = new French();
+
+      conjugatedWord = fr.conjugate('finir', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: false, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('finissons');
+
+      conjugatedWord = fr.conjugate('haïr', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('hais');
+
+      conjugatedWord = fr.conjugate('agir', {mood: 'Indicatif', tense: 'Présent', formal: false, singular: true, person: '1', gender: 'male'});
+      expect(conjugatedWord).to.equal('agis');
+    });
   });
 
   describe('Infinitif Présent', () => {


### PR DESCRIPTION
Redo of French conjugator with tests.

This part will work on all the verbs of group1 (verbs ending in -er), être, avoir and aller in the present tense.

For now, the combineToConjugate() function covers all the cases of combinations between the stems of the verbs in -er and all the possible tense endings for that group.
This means combineToConjugate() already works for all the possible tenses of group1 and can be used as it is, when adding tenses to the French conjugator.
The functions findSubject(), findWordGroup(), combineToConjugate() can be used in the future for the other tenses and groups. 