### PR TITLE
Korean future fix

### DIFF
--- a/src/korean.js
+++ b/src/korean.js
@@ -130,15 +130,15 @@ class Korean {
     const stem = breakdown(word.slice(0, -1));
     if (stem.length < 3) {
       stem.push(8);
-      return `${combineSymbols(stem)} 꺼야`;
+      return `${combineSymbols(stem)} 거야`;
     } else {
       if (stem[stem.length-1] === 17) {
         stem.pop();
-        return `${combineSymbols(stem)}울 꺼야`;
+        return `${combineSymbols(stem)}울 거야`;
       } else if (stem[stem.length-1] === 8) {
-        return `${combineSymbols(stem)} 꺼야`;
+        return `${combineSymbols(stem)} 거야`;
       }
-      return `${combineSymbols(stem)}을 꺼야`;
+      return `${combineSymbols(stem)}을 거야`;
     }
   }
 } // end for class

--- a/src/korean.js
+++ b/src/korean.js
@@ -29,8 +29,7 @@ const combineSymbols = (input) => {
   if(input.length === 3) {
     unicodeTotal += input[2];
   }
-  const finalWord = String.fromCharCode(unicodeTotal);
-  return finalWord;
+  return String.fromCharCode(unicodeTotal);
 };
 
 class Korean {
@@ -131,15 +130,15 @@ class Korean {
     const stem = breakdown(word.slice(0, -1));
     if (stem.length < 3) {
       stem.push(8);
-      return `${combineSymbols(stem)}꺼야`;
+      return `${combineSymbols(stem)} 꺼야`;
     } else {
       if (stem[stem.length-1] === 17) {
         stem.pop();
-        return `${combineSymbols(stem)}울꺼야`;
+        return `${combineSymbols(stem)}울 꺼야`;
       } else if (stem[stem.length-1] === 8) {
-        return `${combineSymbols(stem)}꺼야`;
+        return `${combineSymbols(stem)} 꺼야`;
       }
-      return `${combineSymbols(stem)}을꺼야`;
+      return `${combineSymbols(stem)}을 꺼야`;
     }
   }
 } // end for class

--- a/src/korean.js
+++ b/src/korean.js
@@ -25,11 +25,11 @@ const breakdown = (input) => {
 // input: array of 2 or 3 numbers representing modern jamo (components) that make up a hangul syllable
 // output: a hangul character
 const combineSymbols = (input) => {
-  const initialValue = input[0] * 588;
-  const medialValue = input[1] * 28;
-  const finalValue = input[2] ? input[2] : 0;
-  const total = initialValue + medialValue + finalValue + 44032;
-  const finalWord = String.fromCharCode(total);
+  let unicodeTotal = (input[0] * 588) + (input[1] * 28) + 44032;
+  if(input.length === 3) {
+    unicodeTotal += input[2];
+  }
+  const finalWord = String.fromCharCode(unicodeTotal);
   return finalWord;
 };
 
@@ -129,10 +129,18 @@ class Korean {
 
   doFuture (word) {
     const stem = breakdown(word.slice(0, -1));
-    if (stem[-1] !== 8) {
+    if (stem.length < 3) {
       stem.push(8);
+      return `${combineSymbols(stem)}꺼야`;
+    } else {
+      if (stem[stem.length-1] === 17) {
+        stem.pop();
+        return `${combineSymbols(stem)}울꺼야`;
+      } else if (stem[stem.length-1] === 8) {
+        return `${combineSymbols(stem)}꺼야`;
+      }
+      return `${combineSymbols(stem)}을꺼야`;
     }
-    return `${combineSymbols(stem)}꺼야`;
   }
 } // end for class
 

--- a/test/korean_tests.js
+++ b/test/korean_tests.js
@@ -107,28 +107,48 @@ describe('Korean', () => {
     });
  });
  describe('Future Tense', () => {
-   it('should conjugate regular verbs correctly', () => {
+   it('should conjugate verbs with stem ending with a vowel correctly', () => {
      const kc = new Korean();
-     let presentWord = kc.conjugate('하다', {tense: 'future'});
-     expect(presentWord).to.equal('할꺼야');
+     let futureWord = kc.conjugate('하다', {tense: 'future'});
+     expect(futureWord).to.equal('할꺼야');
 
-     presentWord = kc.conjugate('오다', {tense: 'future'});
-     expect(presentWord).to.equal('올꺼야');
+     futureWord = kc.conjugate('오다', {tense: 'future'});
+     expect(futureWord).to.equal('올꺼야');
 
-     presentWord = kc.conjugate('비다', {tense: 'future'});
-     expect(presentWord).to.equal('빌꺼야');
+     futureWord = kc.conjugate('비다', {tense: 'future'});
+     expect(futureWord).to.equal('빌꺼야');
    });
-   it('should conjugate words with ㄹ final vowel correctly', () => {
+   it('should conjugate verbs with stem ending with a ㄹ consonant correctly',
+   () => {
      const kc = new Korean();
-     let presentWord = kc.conjugate('놀다', {tense: 'future'});
-     expect(presentWord).to.equal('놀꺼야');
+     let futureWord = kc.conjugate('놀다', {tense: 'future'});
+     expect(futureWord).to.equal('놀꺼야');
 
-     presentWord = kc.conjugate('날다', {tense: 'future'});
-     expect(presentWord).to.equal('날꺼야');
+     futureWord = kc.conjugate('날다', {tense: 'future'});
+     expect(futureWord).to.equal('날꺼야');
 
-     presentWord = kc.conjugate('울다', {tense: 'future'});
-     expect(presentWord).to.equal('울꺼야');
+     futureWord = kc.conjugate('울다', {tense: 'future'});
+     expect(futureWord).to.equal('울꺼야');
    });
+   it('should conjugate verbs with stem ending with ㅂ consonant correctly',
+   () => {
+     const kc = new Korean();
+     let futureWord = kc.conjugate('춥다', {tense: 'future'});
+     expect(futureWord).to.equal('추울꺼야');
+
+     futureWord = kc.conjugate('덥다', {tense: 'future'});
+     expect(futureWord).to.equal('더울꺼야');
+   });
+   it('should conjugate verbs with stem ending with other consonants correctly',
+   () => {
+     const kc = new Korean();
+     let futureWord = kc.conjugate('있다', {tense: 'future'});
+     expect(futureWord).to.equal('있을꺼야');
+
+     futureWord = kc.conjugate('먹다', {tense: 'future'});
+     expect(futureWord).to.equal('먹을꺼야');
+   });
+
  });
  describe('Present Continuous Tense', () => {
    it('should conjugate verbs correctly', () => {

--- a/test/korean_tests.js
+++ b/test/korean_tests.js
@@ -110,43 +110,43 @@ describe('Korean', () => {
    it('should conjugate verbs with stem ending with a vowel correctly', () => {
      const kc = new Korean();
      let futureWord = kc.conjugate('하다', {tense: 'future'});
-     expect(futureWord).to.equal('할 꺼야');
+     expect(futureWord).to.equal('할 거야');
 
      futureWord = kc.conjugate('오다', {tense: 'future'});
-     expect(futureWord).to.equal('올 꺼야');
+     expect(futureWord).to.equal('올 거야');
 
      futureWord = kc.conjugate('비다', {tense: 'future'});
-     expect(futureWord).to.equal('빌 꺼야');
+     expect(futureWord).to.equal('빌 거야');
    });
    it('should conjugate verbs with stem ending with a ㄹ consonant correctly',
    () => {
      const kc = new Korean();
      let futureWord = kc.conjugate('놀다', {tense: 'future'});
-     expect(futureWord).to.equal('놀 꺼야');
+     expect(futureWord).to.equal('놀 거야');
 
      futureWord = kc.conjugate('날다', {tense: 'future'});
-     expect(futureWord).to.equal('날 꺼야');
+     expect(futureWord).to.equal('날 거야');
 
      futureWord = kc.conjugate('울다', {tense: 'future'});
-     expect(futureWord).to.equal('울 꺼야');
+     expect(futureWord).to.equal('울 거야');
    });
    it('should conjugate verbs with stem ending with ㅂ consonant correctly',
    () => {
      const kc = new Korean();
      let futureWord = kc.conjugate('춥다', {tense: 'future'});
-     expect(futureWord).to.equal('추울 꺼야');
+     expect(futureWord).to.equal('추울 거야');
 
      futureWord = kc.conjugate('덥다', {tense: 'future'});
-     expect(futureWord).to.equal('더울 꺼야');
+     expect(futureWord).to.equal('더울 거야');
    });
    it('should conjugate verbs with stem ending with other consonants correctly',
    () => {
      const kc = new Korean();
      let futureWord = kc.conjugate('있다', {tense: 'future'});
-     expect(futureWord).to.equal('있을 꺼야');
+     expect(futureWord).to.equal('있을 거야');
 
      futureWord = kc.conjugate('먹다', {tense: 'future'});
-     expect(futureWord).to.equal('먹을 꺼야');
+     expect(futureWord).to.equal('먹을 거야');
    });
 
  });

--- a/test/korean_tests.js
+++ b/test/korean_tests.js
@@ -110,43 +110,43 @@ describe('Korean', () => {
    it('should conjugate verbs with stem ending with a vowel correctly', () => {
      const kc = new Korean();
      let futureWord = kc.conjugate('하다', {tense: 'future'});
-     expect(futureWord).to.equal('할꺼야');
+     expect(futureWord).to.equal('할 꺼야');
 
      futureWord = kc.conjugate('오다', {tense: 'future'});
-     expect(futureWord).to.equal('올꺼야');
+     expect(futureWord).to.equal('올 꺼야');
 
      futureWord = kc.conjugate('비다', {tense: 'future'});
-     expect(futureWord).to.equal('빌꺼야');
+     expect(futureWord).to.equal('빌 꺼야');
    });
    it('should conjugate verbs with stem ending with a ㄹ consonant correctly',
    () => {
      const kc = new Korean();
      let futureWord = kc.conjugate('놀다', {tense: 'future'});
-     expect(futureWord).to.equal('놀꺼야');
+     expect(futureWord).to.equal('놀 꺼야');
 
      futureWord = kc.conjugate('날다', {tense: 'future'});
-     expect(futureWord).to.equal('날꺼야');
+     expect(futureWord).to.equal('날 꺼야');
 
      futureWord = kc.conjugate('울다', {tense: 'future'});
-     expect(futureWord).to.equal('울꺼야');
+     expect(futureWord).to.equal('울 꺼야');
    });
    it('should conjugate verbs with stem ending with ㅂ consonant correctly',
    () => {
      const kc = new Korean();
      let futureWord = kc.conjugate('춥다', {tense: 'future'});
-     expect(futureWord).to.equal('추울꺼야');
+     expect(futureWord).to.equal('추울 꺼야');
 
      futureWord = kc.conjugate('덥다', {tense: 'future'});
-     expect(futureWord).to.equal('더울꺼야');
+     expect(futureWord).to.equal('더울 꺼야');
    });
    it('should conjugate verbs with stem ending with other consonants correctly',
    () => {
      const kc = new Korean();
      let futureWord = kc.conjugate('있다', {tense: 'future'});
-     expect(futureWord).to.equal('있을꺼야');
+     expect(futureWord).to.equal('있을 꺼야');
 
      futureWord = kc.conjugate('먹다', {tense: 'future'});
-     expect(futureWord).to.equal('먹을꺼야');
+     expect(futureWord).to.equal('먹을 꺼야');
    });
 
  });


### PR DESCRIPTION
When I updated the combineSymbol function, I realized the future tense didn't work properly.
The if statement (if (stem[-1] !== 8), line 132) wasn't working correctly and I realized it was coded completely wrong. It pushed 8 to the array for all cases, and we ended up with arrays of 3 or 4 jamo's for latest character of the stem. 3 should be de maximum number of jamo's possible.
We were lucky it passed all the tests before, because the previous combineSymbol function didn't limit the length of the array.
I also realized we missed some cases for the future tense : when the stem ends with a ㅂ consonant, and the other verbs with a stem ending with a consonant other than ㄹ.