### PR TITLE
add info and getInfo to conjugator

### DIFF
--- a/src/french.js
+++ b/src/french.js
@@ -1,3 +1,19 @@
+const info = {
+  tense: {
+    Indicatif: ['Présent', 'Passé Composé', 'Imparfait', 'Plus-que-parfait',
+     'Passé Simple', 'Passé Antérieur','Futur Simple', 'Futur Antérieur'],
+    Subjonctif: ['Présent', 'Passé', 'Imparfait', 'Plus-que-parfait'],
+    Impératif: ['Présent', 'Passé'],
+    Conditionnel: ['Présent', 'Passé 1', 'Passé 2'],
+    Infinitif: ['Présent', 'Passé'],
+    Participe: ['Présent', 'Passé']
+  },
+  gender: ['female', 'male', 'unknown'],
+  singular: [true, false],
+  person: ['1', '2', '3'],
+  formal: [true, false]
+};
+
 class French {
   /*
       word: verb in infinitif form -> can be divided in a stem and an ending
@@ -35,6 +51,10 @@ class French {
           ! 'on' and objects 'can' also have a gender !
       }
   */
+  getInfoList() {
+    return info;
+  }
+
   conjugate (word, info) {
     switch (info.mood) {
       case 'Indicatif':

--- a/src/french.js
+++ b/src/french.js
@@ -1,7 +1,7 @@
-const info = {
+const allInfo = {
   tense: {
     Indicatif: ['Présent', 'Passé Composé', 'Imparfait', 'Plus-que-parfait',
-     'Passé Simple', 'Passé Antérieur','Futur Simple', 'Futur Antérieur'],
+      'Passé Simple', 'Passé Antérieur', 'Futur Simple', 'Futur Antérieur'],
     Subjonctif: ['Présent', 'Passé', 'Imparfait', 'Plus-que-parfait'],
     Impératif: ['Présent', 'Passé'],
     Conditionnel: ['Présent', 'Passé 1', 'Passé 2'],
@@ -51,8 +51,8 @@ class French {
           ! 'on' and objects 'can' also have a gender !
       }
   */
-  getInfoList() {
-    return info;
+  getInfoList () {
+    return allInfo;
   }
 
   conjugate (word, info) {

--- a/src/hindi.js
+++ b/src/hindi.js
@@ -1,4 +1,14 @@
+const info = {
+  tense: ['present', 'past', 'future'],
+  gender: ['m','f'],
+  formal: [true, false],
+  wordType: ['adjective', 'verb']
+};
+
 class Hindi {
+  getInfoList () {
+    return info;
+  }
 
   conjugate (word, info) {
     // Format for info:

--- a/src/hindi.js
+++ b/src/hindi.js
@@ -1,13 +1,13 @@
-const info = {
+const allInfo = {
   tense: ['present', 'past', 'future'],
-  gender: ['m','f'],
+  gender: ['m', 'f'],
   formal: [true, false],
   wordType: ['adjective', 'verb']
 };
 
 class Hindi {
   getInfoList () {
-    return info;
+    return allInfo;
   }
 
   conjugate (word, info) {

--- a/src/korean.js
+++ b/src/korean.js
@@ -32,7 +32,16 @@ const combineSymbols = (input) => {
   return String.fromCharCode(unicodeTotal);
 };
 
+const info = {
+  tense: ['present', 'past', 'future', 'PresentContinuous'],
+  formal: [true, false],
+  wordType: ['adjective', 'verb']
+};
 class Korean {
+
+  getInfoList () {
+    return info;
+  }
 
   conjugate (word, info) {
   // Format for rulesObject: { tense: 'present', formal: 'true/false', wordType: 'adjective/verb'}

--- a/src/korean.js
+++ b/src/korean.js
@@ -32,7 +32,7 @@ const combineSymbols = (input) => {
   return String.fromCharCode(unicodeTotal);
 };
 
-const info = {
+const allInfo = {
   tense: ['present', 'past', 'future', 'PresentContinuous'],
   formal: [true, false],
   wordType: ['adjective', 'verb']
@@ -40,7 +40,7 @@ const info = {
 class Korean {
 
   getInfoList () {
-    return info;
+    return allInfo;
   }
 
   conjugate (word, info) {


### PR DESCRIPTION
@songz 
I'm not sure I did this right or if this is the best way.

I think the values in const info should be defined for the use in the app. All values in the objects in the info object should be strings like 'Female', 'Male', 'True',... and not 'f', 'm', true, ...

and we should have a setInfo(), depending on what the user in the app chose.
and transform 'Female' to 'f', 'Male' to 'm', 'True' to true, ...

And for french for example we could have a list of persons like je, tu, vous, on, ... and then transform this in setInfo into info.singular =  true or false, and info.person = '1', '2', '3'
Maybe we could do this for the other languages too.