### PR TITLE
close issue #125 specify tenses for Truncated form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-conjugator",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Conjugates languages",
   "main": "build/conjugator.js",
   "directories": {

--- a/src/korean.js
+++ b/src/korean.js
@@ -41,7 +41,8 @@ const allInfo = {
     formality: ['formal', 'casual'],
   },
   verb: {
-    tense: ['present', 'past', 'future', 'present continuous', 'prepared', 'truncated', 'conditional', 'state'],
+    tense: ['present', 'past', 'future', 'present continuous', 'prepared', 'present truncated',
+      'past truncated', 'future truncated', 'conditional', 'state'],
     formality: ['formal', 'casual'],
   }
 };
@@ -78,7 +79,16 @@ class Korean {
         return futureConjugation.substring(0, futureConjugation.length - 3);
       }
       case 'truncated':
+      case 'present truncated':
         return word.substring(0, word.length - 1);
+      case 'past truncated': {
+        const pastConjugation = this.doPast(word);
+        return pastConjugation.substring(0, pastConjugation.length - 1);
+      }
+      case 'future truncated': {
+        const futureConjugation = this.doFuture(word);
+        return futureConjugation.substring(0, futureConjugation.length - 3);
+      }
       case 'conditional':
         return this.doConditional(word);
       case 'state':

--- a/test/conjugator_tests.js
+++ b/test/conjugator_tests.js
@@ -46,7 +46,8 @@ describe('Conjugator', () => {
         formality: ['formal', 'casual'],
       },
       verb: {
-        tense: ['present', 'past', 'future', 'present continuous', 'prepared', 'truncated', 'conditional', 'state'],
+        tense: ['present', 'past', 'future', 'present continuous', 'prepared', 'present truncated',
+        'past truncated', 'future truncated', 'conditional', 'state'],
         formality: ['formal', 'casual'],
       }
     });

--- a/test/korean_tests.js
+++ b/test/korean_tests.js
@@ -287,17 +287,39 @@ describe('Korean', () => {
     });
   });
   describe('Truncated form', () => {
-    it('should conjugate verbs correctly for truncated form', () => {
+    it('should conjugate Present verbs correctly for truncated form', () => {
       const kc = new Korean();
-      let truncatedWord = kc.conjugate('하다', {tense: 'Truncated'});
+      let truncatedWord = kc.conjugate('하다', {tense: 'Present Truncated'});
       expect(truncatedWord).to.equal('하');
 
-      truncatedWord = kc.conjugate('부르다', {tense: 'Truncated'});
+      truncatedWord = kc.conjugate('부르다', {tense: 'Present Truncated'});
       expect(truncatedWord).to.equal('부르');
 
-      truncatedWord = kc.conjugate('듣다', {tense: 'Truncated'});
+      truncatedWord = kc.conjugate('듣다', {tense: 'Present Truncated'});
       expect(truncatedWord).to.equal('듣');
      });
+     it('should conjugate Past verbs correctly for truncated form', () => {
+       const kc = new Korean();
+       let truncatedWord = kc.conjugate('하다', {tense: 'Past Truncated'});
+       expect(truncatedWord).to.equal('했');
+
+       truncatedWord = kc.conjugate('부르다', {tense: 'Past Truncated'});
+       expect(truncatedWord).to.equal('불렀');
+
+       truncatedWord = kc.conjugate('듣다', {tense: 'Past Truncated'});
+       expect(truncatedWord).to.equal('들었');
+      });
+      it('should conjugate Future verbs correctly for truncated form', () => {
+        const kc = new Korean();
+        let truncatedWord = kc.conjugate('하다', {tense: 'Future Truncated'});
+        expect(truncatedWord).to.equal('할');
+
+        truncatedWord = kc.conjugate('부르다', {tense: 'Future Truncated'});
+        expect(truncatedWord).to.equal('부를');
+
+        truncatedWord = kc.conjugate('듣다', {tense: 'Future Truncated'});
+        expect(truncatedWord).to.equal('들을');
+       });
   });
   describe('Conditional form', () => {
     it('should conjugate verbs without bottom consonant correctly for conditional form', () => {


### PR DESCRIPTION
This PR adds more Truncated forms, for all tenses: present, past, and future.  

For now the 'truncated' form will be handled as 'present truncated', to be compatible with the current library usage cases.